### PR TITLE
Pin the round advance announcement

### DIFF
--- a/models/league.js
+++ b/models/league.js
@@ -41,7 +41,7 @@ class League {
      */
     getAudience() {
         const audienceId = this.audienceId;
-        
+
         if (!audienceId) {
             return Option.None();
         }


### PR DESCRIPTION
Round advance message will be pinned by the bot. Bot cleans up other
pinned messages, however it does not persist the announcement message
id, so if there are eventually messages it shouldn't unpin, this needs
extending.

Fixes #8 